### PR TITLE
Add user id, license, and bbox arguments to photo search function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,4 @@ Imports: magrittr,
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9000

--- a/R/getPhotoSearch.R
+++ b/R/getPhotoSearch.R
@@ -71,7 +71,7 @@ getPhotoSearch <- function(api_key,
     if (sum(vapply(extras, function(x) {
       x %in% extra_fields
     }, logical(1))) < length(extras)) {
-      print(paste0("One or more of the extra fields provided is not valid or is not supported. Supported extra fields are: ", paste0(extra_fields, collapse = ", ")))
+      stop(paste0("One or more of the extra fields provided is not valid or is not supported. Supported extra fields are: ", paste0(extra_fields, collapse = ", ")))
     }
 
     url = paste0(url, "&extras=", paste0(extras, collapse = ","))

--- a/R/getPhotoSearch.R
+++ b/R/getPhotoSearch.R
@@ -42,7 +42,7 @@
 getPhotoSearch <- function(api_key,
                            user_id = NULL,
                            tags = NULL,
-                           licence_id,
+                           licence_id = NULL,
                            sort = "date-posted-asc",
                            bbox = NULL,
                            extras,

--- a/R/getPhotoSearch.R
+++ b/R/getPhotoSearch.R
@@ -1,13 +1,13 @@
 #' Search for photos on Flickr by user id, tags, license, or bounding box
 #'
-#' R access to flickr search api
+#' R access to Flickr search api
 #'
 #' @param api_key Required. Your API application key
 #' @param user_id The NSID of the user who's photo to search. If this parameter isn't passed then everybody's public photos will be searched.
 #' @param tags List of tags you wish to search for e.g. c("cats, "dogs)
 #' @param license_id The license id for photos (for possible values see the Flickr API method flickr.photos.licenses.getInfo).
 #' @param sort Order to sort returned photos. The possible values are: "date-posted-asc", "date-posted-desc", "date-taken-asc", "date-taken-desc", "interestingness-desc", "interestingness-asc", and "relevance"
-#' @param bbox A object of class bbox or a comma-delimited string of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.
+#' @param bbox A object of class bbox or a numeric vector with values for xmin, ymin, xmax and ymax representing the bottom-left corner of the box and the top-right corner.
 #' @param extras A vector of extra information to fetch for each returned record. Currently supported fields are: c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")
 #' @param per_page Number specifying how many results per page to return. Default 100 results per page. Maximum of 250 if bbox provided or 500 otherwise.
 #' @param page Number specifying which search results page to return. Default is page 1 of results returned.
@@ -33,7 +33,7 @@
 #' # Search for photos tagged "panda" in the area of Ueno Zoo, Tokyo, Japan
 #' getPhotoSearch(api_key = "XXXXXXXXXX",
 #'                tags = "panda",
-#'                bbox = "139.7682226529,35.712627977,139.7724605432,35.7181464141",
+#'                bbox = c(139.7682226529, 35.712627977, 139.7724605432, 35.7181464141),
 #'                extras = c("geo", "owner_name", "tags"))
 #' }
 #'
@@ -69,10 +69,11 @@ getPhotoSearch <- function(api_key,
 
   url = paste0(url, "&sort=", sort)
 
-  if (class(bbox) == "bbox") {
-    bbox <- paste0(bbox[1], ",", bbox[2], ",", bbox[3], ",", bbox[4])
+  if (class(bbox) != "bbox" && length(bbox) != 4) {
+    stop("The bbox provided is not valid. The bbox must be an object of class 'bbox' or a numeric vector with xmin, ymin, xmax and ymax values.")
   }
 
+  bbox = paste0(bbox[1], ",", bbox[2], ",", bbox[3], ",", bbox[4])
   url = paste0(url, "&bbox=", bbox)
 
   if (!missing(extras)) {
@@ -95,7 +96,7 @@ getPhotoSearch <- function(api_key,
     "&format=json&nojsoncallback=1"
   )
 
-  raw_data <- RCurl::getURL(url, ssl.verifypeer = FALSE)
+  raw_data <- RCurl::getURL(url, ssl.verifypeer = FALSE, .mapUnicode = FALSE)
 
   data <- jsonlite::fromJSON(raw_data)
 

--- a/R/getPhotoSearch.R
+++ b/R/getPhotoSearch.R
@@ -1,13 +1,16 @@
-#' Search for photos on Flickr by tags
+#' Search for photos on Flickr by user id, tags, license, or bounding box
 #'
-#' R access to flickr tag search api
+#' R access to flickr search api
 #'
-#' @param api_key Your API application key
+#' @param api_key Required. Your API application key
+#' @param user_id The NSID of the user who's photo to search. If this parameter isn't passed then everybody's public photos will be searched.
 #' @param tags List of tags you wish to search for e.g. c("cats, "dogs)
+#' @param license_id The license id for photos (for possible values see the Flickr API method flickr.photos.licenses.getInfo).
+#' @param bbox A object of class bbox or a comma-delimited list of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.
+#' @param extras A vector of extra information to fetch for each returned record. Currently supported fields are: c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")
+#' @param per_page Number specifying how many results per page to return. Default 100 results per page. Maximum of 250 if bbox provided or 500 otherwise.
 #' @param page Number specifying which search results page to return. Default is page 1 of results returned.
-#' @param per_page Number specifying how many results per page to return. Default 500 results per page.
-#'
-#' @return This function returns data of specific photos matching search tags.
+#' @return This function returns data of specific photos matching search parameters.
 #' @export
 #'
 #' @examples
@@ -15,14 +18,76 @@
 #'   getPhotoSearch(api_key = "XXXXXXXXXX",
 #'                tags= "cats")
 #' }
-getPhotoSearch <- function(api_key, tags, page = 1, per_page = 500){
-  url = paste0("https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=",
-               api_key,
-               "&text=", paste(stringr::str_replace(tags, "@", "%40"), collapse = "%2C"),
-               "&per_page=", per_page,
-               "&page=", page,
-               "&format=json&nojsoncallback=1")
+
+getPhotoSearch <- function(api_key,
+                           user_id,
+                           tags,
+                           licence_id,
+                           bbox,
+                           extras,
+                           per_page = 100,
+                           page = 1) {
+  url = paste0(
+    "https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=",
+    api_key
+  )
+
+  if (!missing(user_id)) {
+    url = paste0(
+      url,
+      "&user_id=",
+      stringr::str_replace(user_id, "@", "%40")
+    )
+  }
+
+  if (!missing(tags)) {
+    url = paste0(
+      url,
+      "&tags=",
+      paste(stringr::str_replace(tags, "@", "%40"), collapse = "%2C")
+    )
+  }
+
+  if (!missing(licence_id)) {
+    if (!(licence_id %in% c(0:10))) {
+      stop("Provided license id is not valid. The license id must be an integer from 0 to 10.")
+    }
+
+    url = paste0(url, "&license=", licence_id)
+  }
+
+  if (!missing(bbox)) {
+    if (class(bbox) == "bbox") {
+      bbox = paste0(bbox[1], ",", bbox[2], ",", bbox[3], ",", bbox[4])
+    }
+
+    url = paste0(url, "&bbox=", bbox)
+  }
+
+  if (!missing(extras)) {
+    extra_fields = c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")
+
+    # Check if all elements of extras are valid extra fields
+    if (sum(vapply(extras, function(x) {
+      x %in% extra_fields
+    }, logical(1))) < length(extras)) {
+      print(paste0("One or more of the extra fields provided is not valid or is not supported. Supported extra fields are: ", paste0(extra_fields, collapse = ", ")))
+    }
+
+    url = paste0(url, "&extras=", paste0(extras, collapse = ","))
+  }
+
+  url = paste0(
+    url,
+    "&per_page=", per_page,
+    "&page=", page,
+    "&format=json&nojsoncallback=1"
+  )
+
+
   raw_data <- RCurl::getURL(url, ssl.verifypeer = FALSE)
+
   data <- jsonlite::fromJSON(raw_data)
+
   as.data.frame(data$photos$photo)
 }

--- a/R/getPhotoSearch.R
+++ b/R/getPhotoSearch.R
@@ -6,7 +6,8 @@
 #' @param user_id The NSID of the user who's photo to search. If this parameter isn't passed then everybody's public photos will be searched.
 #' @param tags List of tags you wish to search for e.g. c("cats, "dogs)
 #' @param license_id The license id for photos (for possible values see the Flickr API method flickr.photos.licenses.getInfo).
-#' @param bbox A object of class bbox or a comma-delimited list of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.
+#' @param sort Order to sort returned photos. The possible values are: "date-posted-asc", "date-posted-desc", "date-taken-asc", "date-taken-desc", "interestingness-desc", "interestingness-asc", and "relevance"
+#' @param bbox A object of class bbox or a comma-delimited string of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.
 #' @param extras A vector of extra information to fetch for each returned record. Currently supported fields are: c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")
 #' @param per_page Number specifying how many results per page to return. Default 100 results per page. Maximum of 250 if bbox provided or 500 otherwise.
 #' @param page Number specifying which search results page to return. Default is page 1 of results returned.
@@ -15,54 +16,64 @@
 #'
 #' @examples
 #' \dontrun{
+#' # Search for photos tagged "cats"
+#' # Return images in descending order of date taken
 #'   getPhotoSearch(api_key = "XXXXXXXXXX",
-#'                tags= "cats")
+#'                sort = "date-taken-desc",
+#'                tags = "cats")
 #' }
+#' \dontrun{
+#' # Search for photos uploaded to the NPS Grand Canyon user account.
+#' # Return extra fields including the date taken and square image URL.
+#'   getPhotoSearch(api_key = "XXXXXXXXXX",
+#'                user_id = "grand_canyon_nps",
+#'                extras = c("date_taken", "url_sq"))
+#' }
+#' #' \dontrun{
+#' # Search for photos tagged "panda" in the area of Ueno Zoo, Tokyo, Japan
+#' getPhotoSearch(api_key = "XXXXXXXXXX",
+#'                tags = "panda",
+#'                bbox = "139.7682226529,35.712627977,139.7724605432,35.7181464141",
+#'                extras = c("geo", "owner_name", "tags"))
+#' }
+#'
+#'
 
 getPhotoSearch <- function(api_key,
-                           user_id,
-                           tags,
+                           user_id = NULL,
+                           tags = NULL,
                            licence_id,
-                           bbox,
+                           sort = "date-posted-asc",
+                           bbox = NULL,
                            extras,
                            per_page = 100,
                            page = 1) {
   url = paste0(
     "https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=",
-    api_key
+    api_key,
+    "&user_id=",
+    stringr::str_replace(user_id, "@", "%40"),
+    "&tags=",
+    paste(stringr::str_replace(tags, "@", "%40"), collapse = "%2C")
   )
 
-  if (!missing(user_id)) {
-    url = paste0(
-      url,
-      "&user_id=",
-      stringr::str_replace(user_id, "@", "%40")
-    )
+  if (!missing(licence_id) && !(licence_id %in% c(0:10))) {
+    stop("The license id provided is not valid. The license id must be an integer from 0 to 10.")
   }
 
-  if (!missing(tags)) {
-    url = paste0(
-      url,
-      "&tags=",
-      paste(stringr::str_replace(tags, "@", "%40"), collapse = "%2C")
-    )
+  url = paste0(url, "&license=", licence_id)
+
+  if (!(sort %in% c("date-posted-asc", "date-posted-desc", "date-taken-asc", "date-taken-desc", "interestingness-desc", "interestingness-asc", "relevance"))) {
+    stop("The sort provided is not valid. Possible sort values are: date-posted-asc, date-posted-desc, date-taken-asc, date-taken-desc, interestingness-desc, interestingness-asc, and relevance.")
   }
 
-  if (!missing(licence_id)) {
-    if (!(licence_id %in% c(0:10))) {
-      stop("Provided license id is not valid. The license id must be an integer from 0 to 10.")
-    }
+  url = paste0(url, "&sort=", sort)
 
-    url = paste0(url, "&license=", licence_id)
+  if (class(bbox) == "bbox") {
+    bbox <- paste0(bbox[1], ",", bbox[2], ",", bbox[3], ",", bbox[4])
   }
 
-  if (!missing(bbox)) {
-    if (class(bbox) == "bbox") {
-      bbox = paste0(bbox[1], ",", bbox[2], ",", bbox[3], ",", bbox[4])
-    }
-
-    url = paste0(url, "&bbox=", bbox)
-  }
+  url = paste0(url, "&bbox=", bbox)
 
   if (!missing(extras)) {
     extra_fields = c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")
@@ -71,7 +82,7 @@ getPhotoSearch <- function(api_key,
     if (sum(vapply(extras, function(x) {
       x %in% extra_fields
     }, logical(1))) < length(extras)) {
-      stop(paste0("One or more of the extra fields provided is not valid or is not supported. Supported extra fields are: ", paste0(extra_fields, collapse = ", ")))
+      stop(paste0("One or more of the extra fields provided is not valid or supported. Supported extra fields are: ", paste0(extra_fields, collapse = ", ")))
     }
 
     url = paste0(url, "&extras=", paste0(extras, collapse = ","))
@@ -83,7 +94,6 @@ getPhotoSearch <- function(api_key,
     "&page=", page,
     "&format=json&nojsoncallback=1"
   )
-
 
   raw_data <- RCurl::getURL(url, ssl.verifypeer = FALSE)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ library(FlickrAPI)
 + getPhotoInfo(api_key, photo_id, output)
 + getExif(api_key, photo_id)
 + getHotTags(api_key, period, count)
-+ getPhotoSearch(api_key, tags, page, per_page)
++ getPhotoSearch(api_key, user_id, tags, licence_id, bbox, extras, per_page, page)
 
 ### See Also
 + [FlickrAPI Description on CRAN](https://cran.r-project.org/web/packages/FlickrAPI/index.html)

--- a/man/getPhotoSearch.Rd
+++ b/man/getPhotoSearch.Rd
@@ -8,7 +8,7 @@ getPhotoSearch(
   api_key,
   user_id = NULL,
   tags = NULL,
-  licence_id,
+  licence_id = NULL,
   sort = "date-posted-asc",
   bbox = NULL,
   extras,

--- a/man/getPhotoSearch.Rd
+++ b/man/getPhotoSearch.Rd
@@ -2,24 +2,41 @@
 % Please edit documentation in R/getPhotoSearch.R
 \name{getPhotoSearch}
 \alias{getPhotoSearch}
-\title{Search for photos on Flickr by tags}
+\title{Search for photos on Flickr by user id, tags, license, or bounding box}
 \usage{
-getPhotoSearch(api_key, tags, page = 1, per_page = 500)
+getPhotoSearch(
+  api_key,
+  user_id,
+  tags,
+  licence_id,
+  bbox,
+  extras,
+  per_page = 100,
+  page = 1
+)
 }
 \arguments{
-\item{api_key}{Your API application key}
+\item{api_key}{Required. Your API application key}
+
+\item{user_id}{The NSID of the user who's photo to search. If this parameter isn't passed then everybody's public photos will be searched.}
 
 \item{tags}{List of tags you wish to search for e.g. c("cats, "dogs)}
 
+\item{bbox}{A object of class bbox or a comma-delimited list of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.}
+
+\item{extras}{A vector of extra information to fetch for each returned record. Currently supported fields are: c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")}
+
+\item{per_page}{Number specifying how many results per page to return. Default 100 results per page. Maximum of 250 if bbox provided or 500 otherwise.}
+
 \item{page}{Number specifying which search results page to return. Default is page 1 of results returned.}
 
-\item{per_page}{Number specifying how many results per page to return. Default 500 results per page.}
+\item{license_id}{The license id for photos (for possible values see the Flickr API method flickr.photos.licenses.getInfo).}
 }
 \value{
-This function returns data of specific photos matching search tags.
+This function returns data of specific photos matching search parameters.
 }
 \description{
-R access to flickr tag search api
+R access to flickr search api
 }
 \examples{
 \dontrun{

--- a/man/getPhotoSearch.Rd
+++ b/man/getPhotoSearch.Rd
@@ -6,10 +6,11 @@
 \usage{
 getPhotoSearch(
   api_key,
-  user_id,
-  tags,
+  user_id = NULL,
+  tags = NULL,
   licence_id,
-  bbox,
+  sort = "date-posted-asc",
+  bbox = NULL,
   extras,
   per_page = 100,
   page = 1
@@ -22,7 +23,9 @@ getPhotoSearch(
 
 \item{tags}{List of tags you wish to search for e.g. c("cats, "dogs)}
 
-\item{bbox}{A object of class bbox or a comma-delimited list of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.}
+\item{sort}{Order to sort returned photos. The possible values are: "date-posted-asc", "date-posted-desc", "date-taken-asc", "date-taken-desc", "interestingness-desc", "interestingness-asc", and "relevance"}
+
+\item{bbox}{A object of class bbox or a comma-delimited string of 4 values defining the Bounding Box of the area that will be searched. The 4 values represent the bottom-left corner of the box and the top-right corner, minimum_longitude, minimum_latitude, maximum_longitude, maximum_latitude.}
 
 \item{extras}{A vector of extra information to fetch for each returned record. Currently supported fields are: c("description", "license", "date_upload", "date_taken", "owner_name", "icon_server", "original_format", "last_update", "geo", "tags", "machine_tags", "o_dims", "views", "media", "path_alias", "url_sq", "url_t", "url_s", "url_q", "url_m", "url_n", "url_z", "url_c", "url_l", "url_o")}
 
@@ -40,7 +43,26 @@ R access to flickr search api
 }
 \examples{
 \dontrun{
+# Search for photos tagged "cats"
+# Return images in descending order of date taken
   getPhotoSearch(api_key = "XXXXXXXXXX",
-               tags= "cats")
+               sort = "date-taken-desc",
+               tags = "cats")
 }
+\dontrun{
+# Search for photos uploaded to the NPS Grand Canyon user account.
+# Return extra fields including the date taken and square image URL.
+  getPhotoSearch(api_key = "XXXXXXXXXX",
+               user_id = "grand_canyon_nps",
+               extras = c("date_taken", "url_sq"))
+}
+#' \dontrun{
+# Search for photos tagged "panda" in the area of Ueno Zoo, Tokyo, Japan
+getPhotoSearch(api_key = "XXXXXXXXXX",
+               tags = "panda",
+               bbox = "139.7682226529,35.712627977,139.7724605432,35.7181464141",
+               extras = c("geo", "owner_name", "tags"))
+}
+
+
 }


### PR DESCRIPTION
I noticed that @fozy81 recently added a photo search function. I expanded on the function to allow user id, license, or geographical bounding box as search arguments. I also added the option to return extra fields. The extra fields optionally include direct link to the photo files so it could also help to implement #6.

Hope this is a welcome addition to the package!